### PR TITLE
Fix doc typo for UserSegmentsApi.getUserSegment function

### DIFF
--- a/docs/UserSegmentsApi.md
+++ b/docs/UserSegmentsApi.md
@@ -161,7 +161,7 @@ var callback = function(error, data, response) {
     console.log('API called successfully. Returned data: ' + data);
   }
 };
-apiInstance.getUserSegment(projectKey, environmentKey, userSegmentKey, , callback);
+apiInstance.getUserSegment(projectKey, environmentKey, userSegmentKey, callback);
 ```
 
 ### Parameters


### PR DESCRIPTION
Small doc typo fix. This one had me confused for a few hours because I thought the intention was for the empty param to be undefined.